### PR TITLE
Kafka cluster configuration

### DIFF
--- a/openshift/kafka/10-amqstreams.yaml
+++ b/openshift/kafka/10-amqstreams.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: amq-streams
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: amq-streams
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: amqstreams.v1.7.1

--- a/openshift/kafka/11-kafka.yaml
+++ b/openshift/kafka/11-kafka.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  labels:
+    app: kafka
+  name: platform-mq
+spec:
+  kafka:
+    config:
+      auto.create.topics.enable: false
+      log.retention.hours: 72
+      num.recovery.threads.per.data.dir: 3
+      offsets.topic.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      transaction.state.log.replication.factor: 1
+
+    replicas: 1
+
+    authorization:
+      type: simple
+      superUsers:
+      - superuser
+      - mirrormaker
+      # because KafkaSource does not support SASL auth
+      # only allowed from within the cluster
+      - ANONYMOUS
+
+    listeners:
+      - name: internal
+        port: 9092
+        type: internal
+        tls: false
+      - name: external
+        port: 9094
+        type: route
+        tls: true
+        authentication:
+          type: scram-sha-512
+
+    jvmOptions:
+      -Xms: 2g
+      -Xmx: 2g
+    resources:
+      limits:
+        cpu: 200m
+        memory: 4Gi
+      requests:
+        cpu: 100m
+        memory: 4Gi
+    storage:
+      deleteClaim: false
+      size: 50Gi
+      type: persistent-claim
+    version: 2.7.0
+
+  zookeeper:
+    replicas: 1
+    storage:
+      deleteClaim: false
+      size: 5Gi
+      type: persistent-claim
+
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  labels:
+    strimzi.io/cluster: platform-mq
+  name: mirrormaker
+spec:
+  authentication:
+    type: scram-sha-512
+

--- a/openshift/kafka/20-knative-kafka.yaml
+++ b/openshift/kafka/20-knative-kafka.yaml
@@ -1,0 +1,9 @@
+apiVersion: operator.serverless.openshift.io/v1alpha1
+kind: KnativeKafka
+metadata:
+  name: knative-kafka
+spec:
+  channel:
+    enabled: false
+  source:
+    enabled: true

--- a/openshift/kafka/21-kafka-source.yaml
+++ b/openshift/kafka/21-kafka-source.yaml
@@ -1,0 +1,43 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: notifications-knative-kafka
+
+parameters:
+- name: BOOTSTRAP_SERVERS
+  value: platform-mq-kafka-bootstrap.kafka:9092
+
+objects:
+- apiVersion: sources.knative.dev/v1beta1
+  kind: KafkaSource
+  metadata:
+    name: notifications-ingress-source
+  spec:
+    consumerGroup: knative
+    bootstrapServers:
+    - ${BOOTSTRAP_SERVERS}
+    topics:
+    - platform.notifications.ingress
+    sink:
+      ref:
+        apiVersion: eventing.knative.dev/v1
+        kind: Broker
+        namespace: hrupp
+        name: mybroker
+
+- apiVersion: sources.knative.dev/v1beta1
+  kind: KafkaSource
+  metadata:
+    name: notifications-ingress-source-jharting
+  spec:
+    consumerGroup: knative-jharting
+    bootstrapServers:
+    - ${BOOTSTRAP_SERVERS}
+    topics:
+    - platform.notifications.ingress
+    sink:
+      ref:
+        apiVersion: eventing.knative.dev/v1
+        kind: Broker
+        namespace: jharting
+        name: default


### PR DESCRIPTION
Sets up a tiny 1-node Kafka Cluster with a public TLS route.
In addition, it sets up a KnativeKafka instance with KafkaSource for routing platform.notifications.ingress messages to knative